### PR TITLE
Update OSEP-04

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ authorurl: http://okfnlabs.org/
 github: http://github.com/openspending/osep/
 mailinglist: http://lists.okfn.org/mailman/listinfo/openspending-dev
 twitter: OpenSpending
+baseurl: "/osep"
 kramdown:
   input: GFM
 gems:

--- a/osep-04.md
+++ b/osep-04.md
@@ -129,21 +129,6 @@ The following properties `SHOULD` be on each resource in `resources`:
 * `title`: a human readable title
 * `description`: a human readable description of the resource contents
 
-
-The following `fields` are required in each `schema` (and therefore, the data that the schema represents):
-
-* `id` (or an *alias*): a unique identifier for this spend line
-* `amount` (or an *alias*): the monetary amount for this spend line
-
-The following `fields` are recommended in each `schema` (and therefore, the data that the schema represents):
-
-* `payee` (or an *alias*): a human readable name for the payee of this spend line
-* `payeeId` (or an *alias*): a unique identifer for the payee
-* `payer` (or an *alias*): a human readable name for the payer of this spend line
-* `payerId` (or an *alias*): a unique identifier for the payer
-
-**If aliases are used, they must be mapped in `openspending.mapping` (see below).**
-
 #### The `openspending` property
 
 The `openspending` property is a `HASH` on the top-level descriptor, and provides implementation metadata for OpenSpending.
@@ -158,6 +143,24 @@ The following properties `MAY` be present on the `openspending` object:
 
 * `spend_resources`: An `ARRAY` which is a list of Resource names, where each name `MUST` be present in the `resources` `ARRAY`. If provided, then **only** these resources are considered spend data proper. If not provided, All resources are considered spend data proper.
 * `mapping`: A `HASH` that maps *alias* field names found in the schema/data to OpenSpending fields. Each key should be a valid OpenSpending field, and each value the name of the field in the data.
+
+#### Data and Schema
+
+Each Resource has a schema for the data therein. There **are** some minimal requirements on any resource that contains spend data, but the **naming** patterns are flexible, due to the `openspending.mapping` field, as described above.
+
+A spend data resource `MUST` have the following:
+
+* A field that represents a unique identifier for each spend line. In OpenSpending, this is called `id`. If it is **not** called `id` in the resource file, then `openspending.mapping` `MUST` have a mapping for `id`.
+* A field that represents the monetary value for each spend line. In OpenSpending, this is called `amount`. If it is **not** called `amount` in the resource file, then `openspending.mapping` `MUST` have a mapping for `amount`.
+
+A spend data resource `SHOULD` have the following:
+
+* A field that represents the Payee name for each spend line. In OpenSpending, this is called `payee`. If it is **not** called `payee` in the resource file, then `openspending.mapping` `MUST` have a mapping for `payee`.
+* A field that represents the Payee ID name for each spend line. In OpenSpending, this is called `payeeId`. If it is **not** called `payeeId` in the resource file, then `openspending.mapping` `MUST` have a mapping for `payeeId`.
+* A field that represents the Payer name for each spend line. In OpenSpending, this is called `payer`. If it is **not** called `payer` in the resource file, then `openspending.mapping` `MUST` have a mapping for `payer`.
+* A field that represents the Payer ID name for each spend line. In OpenSpending, this is called `payerId`. If it is **not** called `payerId` in the resource file, then `openspending.mapping` `MUST` have a mapping for `payerId`.
+
+#### Example
 
 Here's an example of the `datapackage.json` top-level structure:
 

--- a/osep-04.md
+++ b/osep-04.md
@@ -91,15 +91,17 @@ data/my-list-of-projects-the-money-is-associated-with.csv # additional augmentin
 
 ### Required and Recommended Data and Metadata
 
-In order for OpenSpending services to work effectively with raw data sources, we define a set of *requirements* for data and metadata, as well as a set of *recommendations* for metadata and data.
+In order for OpenSpending services to work effectively with raw data sources, we define a set of *requirements* (`MUST` haves) for data and metadata, as well as a set of *recommendations* (`SHOULD` haves) for data and metadata.
 
-OpenSpending Data Packages are a Tabular Data Package Profile, and therefore must implement all the requirements for Tabular Data Packages.
+OpenSpending Data Packages are a Tabular Data Package Profile, and therefore they `MUST` implement all the requirements for Tabular Data Packages.
 
 See the [Data Package][dp] and [Tabular Data Package][tdp] specifications for further details.
 
-OpenSpending Data Packages should move towards full support of the [Budget Data Package][bdp] specification. However, this current proposal does not aim for this support. Budget Data Packages place most metadata on Resource objects, whereas in the current proposal, OpenSpending Data Packages place most metadata on the top-level descriptor, and expect conformity amongst all spend data resources in a single package.
+OpenSpending Data Packages `SHOULD` move towards full support of the [Budget Data Package][bdp] specification. However, this current proposal does not aim for this support.
 
-The following properties are required on the top-level descriptor:
+Budget Data Packages place most metadata on Resource objects, whereas in the current proposal, OpenSpending Data Package places most metadata on the top-level descriptor, and expects conformity amongst all spend data resources in a single package.
+
+The following properties `MUST` be on the top-level descriptor:
 
 * `name`: a url-compatible short name ("slug")
 * `title`: a human readable title
@@ -108,21 +110,25 @@ The following properties are required on the top-level descriptor:
 * `granularity`: a keyword that represents the type of spend data (See [Budget Data Package][bdp-resources])
 * `fiscalYear`: A year (See [Budget Data Package][bdp-resources])
 * `status`: A keyword that represents the status of the data (See [Budget Data Package][bdp-resources])
+* `type`: A keyword that represents the *direction* of the spend (See [Budget Data Package][bdp-resources])
 * `openspending`: a hash that provides implementation metadata for OpenSpending (see below for detailed information)
 * `resources`: an array of [Data Resources][dp-resources]
 
-The following properties are recommended on the top-level descriptor:
+The following properties `SHOULD` be on the top-level descriptor:
 
 * `location`: A valid ISO code (See [Budget Data Package][bdp-resources])
-* `type`: A keyword that represents the *direction* of the spend (See [Budget Data Package][bdp-resources])
 
-The following properties are required on each resource in `resources`:
+The following properties `MUST` be on each resource in `resources`:
 
 * `url`, `path` or `data`: which provides the actual data
 * `name`: a url-compatible short name ("slug")
+* `schema`: a [JSON Table Schema][jts] that describes the structure of the CSV
+
+The following properties `SHOULD` be on each resource in `resources`:
+
 * `title`: a human readable title
 * `description`: a human readable description of the resource contents
-* `schema`: a [JSON Table Schema][jts] that describes the structure of the CSV
+
 
 The following `fields` are required in each `schema` (and therefore, the data that the schema represents):
 
@@ -144,7 +150,7 @@ The `openspending` property is a `HASH` on the top-level descriptor, and provide
 
 For v1 of the OpenSpending Data Package we proposed to largely reuse structures from the current OpenSpending data model.
 
-The following properties are required on the `openspending` object:
+The following properties `MUST` be on the `openspending` object:
 
 * `owner`: a string which is the username of the OpenSpending account that the package belongs to
 

--- a/osep-04.md
+++ b/osep-04.md
@@ -14,7 +14,7 @@ redirect_from: "/04-openspending-data-package.html"
 
 The specification of an OpenSpending Data Package is an essential part of the move to a flat-file based DataStore (see [OSEP-02][osep-02] and [OSEP-6][osep-06]) and [Github Issue 669][issue-669].
 
-OpenSpending Data Packages are a *[Profile][dp-profiles]* of the [Tabular Data Package][tdp] format, and also implement significant portions of the [Budget Data Package][bdp] specification, albeit in a different manner.
+OpenSpending Data Packages are a *[Profile][dp-profiles]* of the [Tabular Data Package][tdp] format, and also implement significant portions of the [Budget Data Package][bdp] specification, albeit in a different manner. We do plan to syncronize OpenSpending Data Package and Budget Data Package in the near future.
 
 The OpenSpending Data Package specification aims to provide support for:
 
@@ -36,7 +36,7 @@ An **OpenSpending Data Package** is a Data Package Profile that extends Tabular 
 
 OpenSpending stores spend data of both agreggate and transactional form. Currently, data is managed in a relational database. In moving to a flat file DataStore for all "raw" data in OpenSpending, we require a way to provide metadata for the data in a structured form, as well as a canonical way to access the spend data from the raw sources.
 
-Additionally, we want to provide flexibility in how users structure their source data, while still providing a consistent interface that OpenSpending services (see [OSEP-02][osep-02]) can rely on to access raw data.
+Additionally, we want to provide flexibility in how users structure their source data, while still providing a consistent interface that OpenSpending services (see [OSEP-01][osep-01]) can rely on to access raw data.
 
 Finally, we want to widen the use cases that OpenSpending can support. Part of the solution for this is to provide a way to store and reference additional data that supports the core spend data. OpenSpending Data Package provides structure for this.
 
@@ -243,6 +243,7 @@ There is no material for the appendix at present.
 
 
 [issue-669]: https://github.com/openspending/openspending/issues/669
+[osep-01]: http://labs.openspending.org/osep/osep-01.html
 [osep-02]: http://labs.openspending.org/osep/osep-02.html
 [osep-06]: http://labs.openspending.org/osep/osep-06.html
 [dp]: http://dataprotocols.org/data-packages/

--- a/osep-04.md
+++ b/osep-04.md
@@ -18,8 +18,9 @@ OpenSpending Data Packages are a *[Profile][dp-profiles]* of the [Tabular Data P
 
 The OpenSpending Data Package specification aims to provide support for:
 
+* Mapping source data to integral parts of the OpenSpending data model (measures such as monetary values, and dimensions such as time, related entities, and so on).
 * Packaging either normalized or denormalized data sources for use in OpenSpending.
-* Packaging resources that are *referenced* by the spend data proper, but that do not actually contain spend data.
+* Packaging resources that are *referenced* by the spend data proper, but that do not actually contain spend data. This could mean, for example, rich data on the recipients of funds, or projects associated with a particular set of data.
 * Progressive enhancement of data via a range of *recommended*, but not *required* metadata, in order to address new use cases for the OpenSpending platform going forward.
 
 Leveraging [Data Package][dp] also opens up new opportunities to reuse/remix data from Open Spending with other tools and platforms in the [Frictionless Data][fd] ecosystem.

--- a/osep-04.md
+++ b/osep-04.md
@@ -77,6 +77,18 @@ archive/my-original-data.xls
 scripts/scrape-and-clean-the-data.py
 ```
 
+And, an example of a data package with normalized data could be:
+
+```
+datapackage.json
+README.md
+
+# data files, but only the first one actually contains the spend data. It may contain references (foreign keys) to the other files.
+data/my-financial-data.csv # actually contains spend data
+data/my-list-of-entities-receiving-money.csv # data that augmented the spend data
+data/my-list-of-projects-the-money-is-associated-with.csv # additional augmenting data
+```
+
 ### Required and Recommended Data and Metadata
 
 In order for OpenSpending services to work effectively with raw data sources, we define a set of *requirements* for data and metadata, as well as a set of *recommendations* for metadata and data.

--- a/osep-04.md
+++ b/osep-04.md
@@ -4,36 +4,53 @@ title: OpenSpending Data Package
 osep: 4
 discussion: https://github.com/openspending/osep/issues/6
 created: 8 December 2013
-updated: 23 April 2014
+updated: 28 April 2015
 authors: Rufus Pollock, Paul Walsh
 accepted:
 redirect_from: "/04-openspending-data-package.html"
 ---
 
-The specification of an OpenSpending Data Package is an essential part of the
-move to a flat-file based DataStore (see OSEP 2) and [Github Issue
-669][issue-669].
+## Overview
 
-[issue-669]: https://github.com/openspending/openspending/issues/669
+The specification of an OpenSpending Data Package is an essential part of the move to a flat-file based DataStore (see [OSEP-02][osep-02] and [OSEP-6][osep-06]) and [Github Issue 669][issue-669].
 
-## OpenSpending Data Package
+OpenSpending Data Packages are a *[Profile][dp-profiles]* of the [Tabular Data Package][tdp] format, and also implement significant portions of the [Budget Data Package][bdp] specification, albeit in a different manner.
 
-An OpenSpending data package is an extension of the [Budget Data Package][bdp]
-which is, in turn, an extension of the [Tabular Data Package][tdp].
+The OpenSpending Data Package specification aims to provide support for:
 
-[bdp]: https://github.com/openspending/budget-data-package
+* Packaging either normalized or denormalized data sources for use in OpenSpending.
+* Packaging resources that are *referenced* by the spend data proper, but that do not actually contain spend data.
+* Progressive enhancement of data via a range of *recommended*, but not *required* metadata, in order to address new use cases for the OpenSpending platform going forward.
 
-Key points:
+Leveraging [Data Package][dp] also opens up new opportunities to reuse/remix data from Open Spending with other tools and platforms in the [Frictionless Data][fd] ecosystem.
 
-* It is a [Data Package][dp] and stores descriptor information in
-  `datapackage.json`
-* Data is stored in well-structured CSV files
+## Background
 
-[tdp]: http://dataprotocols.org/tabular-data-package/
-[dp]: http://dataprotocols.org/data-packages/
+The [Data Package][dp] specifications are a family of formats for standardised publishing of data.
 
-To summarize, an OpenSpending Data Package on disk or in our store at
-http://data.openspending.org/ will look something like this:
+Data Packages can have *[Profiles][dp-profiles]*, which extend base specifications towards more specific application.
+
+[Tabular Data Package][tdp] describes a publishing standard specifically for tabular data (e.g.: CSV). [Budget Data Package][bdp] is a profile that extends Tabular Data Package to describe a publishing standard for both transactional and aggregate fiscal data.
+
+An **OpenSpending Data Package** is a Data Package Profile that extends Tabular Data Package, with *spend data* resources that have a similar schema and required field set to resources in Budget Data Package.
+
+OpenSpending stores spend data of both agreggate and transactional form. Currently, data is managed in a relational database. In moving to a flat file DataStore for all "raw" data in OpenSpending, we require a way to provide metadata for the data in a structured form, as well as a canonical way to access the spend data from the raw sources.
+
+Additionally, we want to provide flexibility in how users structure their source data, while still providing a consistent interface that OpenSpending services (see [OSEP-02][osep-02]) can rely on to access raw data.
+
+Finally, we want to widen the use cases that OpenSpending can support. Part of the solution for this is to provide a way to store and reference additional data that supports the core spend data. OpenSpending Data Package provides structure for this.
+
+## Proposal
+
+An OpenSpending Data Package is a Tabular Data Package Profile.
+
+At the bare minimum, that means:
+
+* Data is stored in well-structured CSV files, refered to as "resources"
+* Resources and additional metadata is provided via a `datapackage.json` descriptor
+* Usually, the descriptor and the resources will be co-located in a directory, and this directory represents the "Data Package"
+
+a simple example of an OpenSpending Data Package on disk, or in the DataStore, will look like this:
 
 ```
 datapackage.json
@@ -41,7 +58,7 @@ datapackage.json
 data/my-financial-data.csv
 ```
 
-A more complex version may have additional files
+A more complex example may have additional files:
 
 ```
 datapackage.json
@@ -59,55 +76,105 @@ archive/my-original-data.xls
 scripts/scrape-and-clean-the-data.py
 ```
 
-### OpenSpending Data Package Profile
+### Required and Recommended Data and Metadata
 
-This documents the specific structure of the JSON metadata stored in the
-`datapackage.json`.
+In order for OpenSpending services to work effectively with raw data sources, we define a set of *requirements* for data and metadata, as well as a set of *recommendations* for metadata and data.
 
-* Base metadata is as per [Budget Data Package spec][bdp]
-* Subsection under key "openspending"
+OpenSpending Data Packages are a Tabular Data Package Profile, and therefore must implement all the requirements for Tabular Data Packages.
+
+See the [Data Package][dp] and [Tabular Data Package][tdp] specifications for further details.
+
+OpenSpending Data Packages should move towards full support of the [Budget Data Package][bdp] specification. However, this current proposal does not aim for this support. Budget Data Packages place most metadata on Resource objects, whereas in the current proposal, OpenSpending Data Packages place most metadata on the top-level descriptor, and expect conformity amongst all spend data resources in a single package.
+
+The following properties are required on the top-level descriptor:
+
+* `name`: a url-compatible short name ("slug")
+* `title`: a human readable title
+* `profiles`: an array which declares the profile type(s) of the Data Package [see here][dp-profiles]
+* `currency`: a currency code for this data (See [Budget Data Package][bdp-resources])
+* `granularity`: a keyword that represents the type of spend data (See [Budget Data Package][bdp-resources])
+* `fiscalYear`: A year (See [Budget Data Package][bdp-resources])
+* `status`: A keyword that represents the status of the data (See [Budget Data Package][bdp-resources])
+* `openspending`: a hash that provides implementation metadata for OpenSpending (see below for detailed information)
+* `resources`: an array of [Data Resources][dp-resources]
+
+The following properties are recommended on the top-level descriptor:
+
+* `location`: A valid ISO code (See [Budget Data Package][bdp-resources])
+* `type`: A keyword that represents the *direction* of the spend (See [Budget Data Package][bdp-resources])
+
+The following properties are required on each resource in `resources`:
+
+* `url`, `path` or `data`: which provides the actual data
+* `name`: a url-compatible short name ("slug")
+* `title`: a human readable title
+* `description`: a human readable description of the resource contents
+* `schema`: a [JSON Table Schema][jts] that describes the structure of the CSV
+
+The following `fields` are required in each `schema` (and therefore, the data that the schema represents):
+
+* `id` (or an *alias*): a unique identifier for this spend line
+* `amount` (or an *alias*): the monetary amount for this spend line
+
+The following `fields` are recommended in each `schema` (and therefore, the data that the schema represents):
+
+* `payee` (or an *alias*): a human readable name for the payee of this spend line
+* `payeeId` (or an *alias*): a unique identifer for the payee
+* `payer` (or an *alias*): a human readable name for the payer of this spend line
+* `payerId` (or an *alias*): a unique identifier for the payer
+
+**If aliases are used, they must be mapped in `openspending.mapping` (see below).**
+
+#### The `openspending` property
+
+The `openspending` property is a `HASH` on the top-level descriptor, and provides implementation metadata for OpenSpending.
+
+For v1 of the OpenSpending Data Package we proposed to largely reuse structures from the current OpenSpending data model.
+
+The following properties are required on the `openspending` object:
+
+* `owner`: a string which is the username of the OpenSpending account that the package belongs to
+
+The following properties `MAY` be present on the `openspending` object:
+
+* `spend_resources`: An `ARRAY` which is a list of Resource names, where each name `MUST` be present in the `resources` `ARRAY`. If provided, then **only** these resources are considered spend data proper. If not provided, All resources are considered spend data proper.
+* `mapping`: A `HASH` that maps *alias* field names found in the schema/data to OpenSpending fields. Each key should be a valid OpenSpending field, and each value the name of the field in the data.
+* `views`: `MAY` have a `views` attribute defining visualizations or views onto the data. If present, it MUST follow the structure defined in the [views specification in the OpenSpending documentation][views].
+
+Here's an example of the `datapackage.json` top-level structure:
 
 ```
-"name": ...
-"title": ...
-"currency": ...
+"name": ...,
+"title": ...,
 "profiles": [
-  "openspending": "1"
-  "budget-data-package": ...
+  "openspending": "*"
 },
+"currency": ...,
+"granularity": ...,
+"fiscalYear": ...,
 "openspending": {
-  ... openspending specific profile info - see below
+  "owner": "me",
+  "spend_resources": ["my-budget"]
+  "mapping": {
+    "id": "pk",
+    "amount": "total"
+  }
 }
 "resources": [
-  ... as per Tabular Data Package and Budget Data Package ...
+  {
+    "name": "my-budget",
+    "title": ...,
+    "path": ...
+  },
+  {
+    "name": "my-counties",
+    "title": ...,
+    "path": ...
+  }
 ]
-...
 ```
 
-#### `openspending` entry
-
-The `openspending` entry in the `datapackage.json` is for OpenSpending specific
-additions. For v1 of the OS Data Package Profile we proposed to largely reuse
-structures from current OpenSpending.
-
-Specifically `openspending` entry in `datapackage.json`:
-
-* MUST be a JSON object `{}`
-* MAY have a `mapping` attribute providing a mapping of the data (CSV file in
-  `resources`) to the Database. If present it MUST follow the structure defined
-  in the [mapping specification in the OpenSpending documentation][mapping].
-* MAY have a `views` attribute defining visualizations or views onto the data.
-  If present, it MUST follow the structure defined in the [views specification
-  in the OpenSpending documentation][views].
-
-> Note: Budget data package has some required and standardized fields in the
-> CSV. One may be able to automatically generate a mapping on this basis.
-> However, this may be something for a separate `mapping` generator tool.
-
-[mapping]: http://docs.openspending.org/en/latest/model/design.html#views-and-pre-defined-visualizations
-[views]: http://docs.openspending.org/en/latest/model/design.html#views-and-pre-defined-visualizations
-
-#### Migration of Current OpenSpending Metadata
+### Migration of Current OpenSpending Metadata
 
 Full [documentation of the current OpenSpending JSON data model is
 here][current]. The top-level structure is as follows:
@@ -149,7 +216,7 @@ Migration of metadata is relatively simple:
 * `mapping` - moves to `openspending.mapping`
 * `views` - moves to `openspending.views`
 
-## Structuring Data
+### Structuring Data
 
 * Recommendations about structuring the data
   * For datasets like to be below 10MB store into one file
@@ -162,10 +229,29 @@ Migration of metadata is relatively simple:
 * Versioning data - we recommend turning on s3 versioning so we don't need to
   worry about accidental data loss
 
-## Extras (under discussion)
+### Extras (under discussion)
 
 * `archive` directory is for data that is not for openspending directly but is
   useful to archive raw data files from which data was extracted
 * Note it is possible to store the data elsewhere than in data.openspending.org -
   you can have datapackage.json point to files somewhere else on the web
     (though we may still want to cache that at some point)
+
+## Appendix
+
+There is no material for the appendix at present.
+
+
+[issue-669]: https://github.com/openspending/openspending/issues/669
+[osep-02]: http://labs.openspending.org/osep/osep-02.html
+[osep-06]: http://labs.openspending.org/osep/osep-06.html
+[dp]: http://dataprotocols.org/data-packages/
+[tdp]: http://dataprotocols.org/tabular-data-package/
+[bdp]: https://github.com/openspending/budget-data-package
+[bdp-resources]: https://github.com/openspending/budget-data-package/blob/master/specification.md#budget-specific-metadata
+[dp-profiles]: https://github.com/dataprotocols/dataprotocols/issues/183
+[dp-resources]: http://dataprotocols.org/data-packages/#resource-information
+[fd]: http://data.okfn.org
+[mapping]: http://docs.openspending.org/en/latest/model/design.html#views-and-pre-defined-visualizations
+[views]: http://docs.openspending.org/en/latest/model/design.html#views-and-pre-defined-visualizations
+[jts]: http://dataprotocols.org/json-table-schema/

--- a/osep-04.md
+++ b/osep-04.md
@@ -158,7 +158,6 @@ The following properties `MAY` be present on the `openspending` object:
 
 * `spend_resources`: An `ARRAY` which is a list of Resource names, where each name `MUST` be present in the `resources` `ARRAY`. If provided, then **only** these resources are considered spend data proper. If not provided, All resources are considered spend data proper.
 * `mapping`: A `HASH` that maps *alias* field names found in the schema/data to OpenSpending fields. Each key should be a valid OpenSpending field, and each value the name of the field in the data.
-* `views`: `MAY` have a `views` attribute defining visualizations or views onto the data. If present, it MUST follow the structure defined in the [views specification in the OpenSpending documentation][views].
 
 Here's an example of the `datapackage.json` top-level structure:
 

--- a/osep-04.md
+++ b/osep-04.md
@@ -4,7 +4,7 @@ title: OpenSpending Data Package
 osep: 4
 discussion: https://github.com/openspending/osep/issues/6
 created: 8 December 2013
-updated: 28 April 2015
+updated: 1 May 2015
 authors: Rufus Pollock, Paul Walsh
 accepted:
 redirect_from: "/04-openspending-data-package.html"
@@ -107,16 +107,23 @@ The following properties `MUST` be on the top-level descriptor:
 * `title`: a human readable title
 * `profiles`: an array which declares the profile type(s) of the Data Package [see here][dp-profiles]
 * `currency`: a currency code for this data (See [Budget Data Package][bdp-resources])
-* `granularity`: a keyword that represents the type of spend data (See [Budget Data Package][bdp-resources])
-* `fiscalYear`: A year (See [Budget Data Package][bdp-resources])
-* `status`: A keyword that represents the status of the data (See [Budget Data Package][bdp-resources])
-* `type`: A keyword that represents the *direction* of the spend (See [Budget Data Package][bdp-resources])
 * `openspending`: a hash that provides implementation metadata for OpenSpending (see below for detailed information)
 * `resources`: an array of [Data Resources][dp-resources]
 
 The following properties `SHOULD` be on the top-level descriptor:
 
-* `location`: A valid ISO code (See [Budget Data Package][bdp-resources])
+* `location`: A valid ISO code (See [Budget Data Package][bdp-resources]), or, array of valid ISO codes
+
+> # TODO: How do we handle regions (cities, continents, etc.) that are not represented by an ISO code?
+
+The following properties `MAY` be on the top-level descriptor:
+
+* `granularity`: a keyword that represents the type of spend data (See [Budget Data Package][bdp-resources])
+* `fiscalYear`: A year (See [Budget Data Package][bdp-resources])
+* `type`: A keyword that represents the *direction* of the spend (See [Budget Data Package][bdp-resources]). If not included, `type` defaults to "expenditure"
+* `status`: A keyword that represents the status of the data (See [Budget Data Package][bdp-resources])
+
+> # TODO: Use a more descriptive name for type, and also suggest a change upstream in BDP?
 
 The following properties `MUST` be on each resource in `resources`:
 
@@ -141,8 +148,7 @@ The following properties `MUST` be on the `openspending` object:
 
 The following properties `MAY` be present on the `openspending` object:
 
-* `spend_resources`: An `ARRAY` which is a list of Resource names, where each name `MUST` be present in the `resources` `ARRAY`. If provided, then **only** these resources are considered spend data proper. If not provided, All resources are considered spend data proper.
-* `mapping`: A `HASH` that maps *alias* field names found in the schema/data to OpenSpending fields. Each key should be a valid OpenSpending field, and each value the name of the field in the data.
+* `mapping`: A `HASH` that maps *alias* field names found in the schema/data to OpenSpending fields. Each key should be a valid OpenSpending field, and each value is an `ARRAY` of strings in the format "{RESOURCE_NAME}/{FIELD_NAME}". Glob patterns `MAY` be used for the {RESOURCE_NAME} portion in order to match multiple resources.
 
 #### Data and Schema
 
@@ -175,10 +181,9 @@ Here's an example of the `datapackage.json` top-level structure:
 "fiscalYear": ...,
 "openspending": {
   "owner": "me",
-  "spend_resources": ["my-budget"]
   "mapping": {
-    "id": "pk",
-    "amount": "total"
+    "id": ["my-budget/pk"],
+    "amount": ["my-budget/total"]
   }
 }
 "resources": [


### PR DESCRIPTION
As discussed [here](https://discuss.okfn.org/t/openspending-data-package-structure/239/4) this is an update to OSEP-4.

I've gone into some more detail, than previously discussed, while thinking through various scenarios, so @rgrp @tryggvib I'd rather some comments on the pull request before merging it in, even in draft status.

Things I've tried to address that were not clear (at least to me) to date:
- Some clear language on relation to Budget Data Package
- Some treatment of fields on BDP that are obviously needed here (e.g.: status)
- The issue of "resources that aren't spend data, and `openspending.mapping`: I've introduced `openspending.spend_resources`

Let's at least discuss these things before merging.
